### PR TITLE
Change: navigation context

### DIFF
--- a/src/NavStack/Assets/NavStack/Runtime/External/R3/PageObservableExtensions.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/External/R3/PageObservableExtensions.cs
@@ -7,14 +7,14 @@ namespace NavStack
 {
     public static class PageObservableExtensions
     {
-        public static Observable<NavigationOptions> OnAppearAsObservable(this IPage page)
+        public static Observable<NavigationContext> OnAppearAsObservable(this IPage page)
         {
             var e = new OnAppearObservable();
             page.LifecycleEvents.Add(e);
             return e.AsObservable();
         }
 
-        public static Observable<NavigationOptions> OnDisappearAsObservable(this IPage page)
+        public static Observable<NavigationContext> OnDisappearAsObservable(this IPage page)
         {
             var e = new OnDisappearObservable();
             page.LifecycleEvents.Add(e);
@@ -30,12 +30,12 @@ namespace NavStack
 
         sealed class OnAppearObservable : IPageLifecycleEvent
         {
-            readonly Subject<NavigationOptions> subject = new();
-            public Observable<NavigationOptions> AsObservable() => subject;
+            readonly Subject<NavigationContext> subject = new();
+            public Observable<NavigationContext> AsObservable() => subject;
 
-            UniTask IPageLifecycleEvent.OnAppear(NavigationOptions options, CancellationToken cancellationToken)
+            UniTask IPageLifecycleEvent.OnAppear(NavigationContext context, CancellationToken cancellationToken)
             {
-                subject.OnNext(options);
+                subject.OnNext(context);
                 return UniTask.CompletedTask;
             }
 
@@ -48,12 +48,12 @@ namespace NavStack
 
         sealed class OnDisappearObservable : IPageLifecycleEvent
         {
-            readonly Subject<NavigationOptions> subject = new();
-            public Observable<NavigationOptions> AsObservable() => subject;
+            readonly Subject<NavigationContext> subject = new();
+            public Observable<NavigationContext> AsObservable() => subject;
 
-            UniTask IPageLifecycleEvent.OnDisappear(NavigationOptions options, CancellationToken cancellationToken)
+            UniTask IPageLifecycleEvent.OnDisappear(NavigationContext context, CancellationToken cancellationToken)
             {
-                subject.OnNext(options);
+                subject.OnNext(context);
                 return UniTask.CompletedTask;
             }
 

--- a/src/NavStack/Assets/NavStack/Runtime/INavigationSheet.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/INavigationSheet.cs
@@ -8,7 +8,7 @@ namespace NavStack
         UniTask AddAsync(IPage page, CancellationToken cancellationToken = default);
         UniTask RemoveAsync(IPage page, CancellationToken cancellationToken = default);
         UniTask RemoveAllAsync(CancellationToken cancellationToken = default);
-        UniTask ShowAsync(int index, NavigationOptions options, CancellationToken cancellationToken = default);
-        UniTask HideAsync(NavigationOptions options, CancellationToken cancellationToken = default);
+        UniTask ShowAsync(int index, NavigationContext context, CancellationToken cancellationToken = default);
+        UniTask HideAsync(NavigationContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NavStack/Assets/NavStack/Runtime/INavigationStack.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/INavigationStack.cs
@@ -6,8 +6,8 @@ namespace NavStack
 {
     public interface INavigationStack : INavigation
     {
-        UniTask PushAsync(IPage page, NavigationOptions options, CancellationToken cancellationToken = default);
-        UniTask PushAsync(Func<UniTask<IPage>> factory, NavigationOptions options, CancellationToken cancellationToken = default);
-        UniTask PopAsync(NavigationOptions options, CancellationToken cancellationToken = default);
+        UniTask PushAsync(IPage page, NavigationContext context, CancellationToken cancellationToken = default);
+        UniTask PushAsync(Func<UniTask<IPage>> factory, NavigationContext context, CancellationToken cancellationToken = default);
+        UniTask PopAsync(NavigationContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NavStack/Assets/NavStack/Runtime/IPage.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/IPage.cs
@@ -9,7 +9,7 @@ namespace NavStack
         IList<IPageLifecycleEvent> LifecycleEvents { get; }
         UniTask OnInitialize(CancellationToken cancellationToken = default);
         UniTask OnCleanup(CancellationToken cancellationToken = default);
-        UniTask OnAppear(NavigationOptions options, CancellationToken cancellationToken = default);
-        UniTask OnDisappear(NavigationOptions options, CancellationToken cancellationToken = default);
+        UniTask OnAppear(NavigationContext context, CancellationToken cancellationToken = default);
+        UniTask OnDisappear(NavigationContext context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NavStack/Assets/NavStack/Runtime/IPageLifecycleEvent.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/IPageLifecycleEvent.cs
@@ -7,7 +7,7 @@ namespace NavStack
     {
         UniTask OnInitialize(CancellationToken cancellationToken = default) => UniTask.CompletedTask;
         UniTask OnCleanup(CancellationToken cancellationToken = default) => UniTask.CompletedTask;
-        UniTask OnAppear(NavigationOptions options, CancellationToken cancellationToken = default) => UniTask.CompletedTask;
-        UniTask OnDisappear(NavigationOptions options, CancellationToken cancellationToken = default) => UniTask.CompletedTask;
+        UniTask OnAppear(NavigationContext context, CancellationToken cancellationToken = default) => UniTask.CompletedTask;
+        UniTask OnDisappear(NavigationContext context, CancellationToken cancellationToken = default) => UniTask.CompletedTask;
     }
 }

--- a/src/NavStack/Assets/NavStack/Runtime/Internal/NavigationHelper.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/Internal/NavigationHelper.cs
@@ -20,17 +20,17 @@ namespace NavStack
 
     internal static class NavigationHelper
     {
-        public static async UniTask InvokeOnAppear(IPage page, List<INavigationCallbackReceiver> callbackReceivers, NavigationOptions options, CancellationToken cancellationToken)
+        public static async UniTask InvokeOnAppear(IPage page, List<INavigationCallbackReceiver> callbackReceivers, NavigationContext context, CancellationToken cancellationToken)
         {
             InvokeCallback(page, callbackReceivers, PageCallbackType.OnBeforeAppear);
-            await page.OnAppear(options, cancellationToken);
+            await page.OnAppear(context, cancellationToken);
             InvokeCallback(page, callbackReceivers, PageCallbackType.OnAfterAppear);
         }
 
-        public static async UniTask InvokeOnDisappear(IPage page, List<INavigationCallbackReceiver> callbackReceivers, NavigationOptions options, CancellationToken cancellationToken)
+        public static async UniTask InvokeOnDisappear(IPage page, List<INavigationCallbackReceiver> callbackReceivers, NavigationContext context, CancellationToken cancellationToken)
         {
             InvokeCallback(page, callbackReceivers, PageCallbackType.OnBeforeDisappear);
-            await page.OnDisappear(options, cancellationToken);
+            await page.OnDisappear(context, cancellationToken);
             InvokeCallback(page, callbackReceivers, PageCallbackType.OnAfterDisappear);
         }
 

--- a/src/NavStack/Assets/NavStack/Runtime/NavigationContext.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/NavigationContext.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace NavStack
+{
+    public class NavigationContext
+    {
+        public NavigationOptions Options { get; set; }
+        public IDictionary<object, object> Parameters { get; set; } = new Dictionary<object, object>();
+
+        public virtual NavigationContext CreateCopy()
+        {
+            var context = new NavigationContext()
+            {
+                Options = new(Options),
+                Parameters = new Dictionary<object, object>()
+            };
+
+            foreach (var kv in Parameters)
+            {
+                context.Parameters.Add(kv);
+            }
+
+            return context;
+        }
+    }
+}

--- a/src/NavStack/Assets/NavStack/Runtime/NavigationContext.cs.meta
+++ b/src/NavStack/Assets/NavStack/Runtime/NavigationContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c6e8b5ddc0644ef3ac4f5eb5ad2a719
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/NavStack/Assets/NavStack/Runtime/NavigationOptions.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/NavigationOptions.cs
@@ -9,6 +9,8 @@ namespace NavStack
         public NavigationOptions() { }
         public NavigationOptions(NavigationOptions source)
         {
+            if (source == null) return;
+            
             animated = source.animated;
             awaitOperation = source.awaitOperation;
         }

--- a/src/NavStack/Assets/NavStack/Runtime/NavigationSheetExtensions.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/NavigationSheetExtensions.cs
@@ -10,7 +10,7 @@ namespace NavStack
     {
         public static UniTask ShowAsync(this INavigationSheet navigationSheet, int index, CancellationToken cancellationToken = default)
         {
-            return navigationSheet.ShowAsync(index, navigationSheet.DefaultOptions, cancellationToken);
+            return navigationSheet.ShowAsync(index, new NavigationContext(), cancellationToken);
         }
 
         public static UniTask AddNewObjectAsync<T>(this INavigationSheet navigationSheet, T prefab, CancellationToken cancellationToken = default)
@@ -30,17 +30,17 @@ namespace NavStack
             return AddNewObjectAsync(navigationSheet, key, ResourceProvider.DefaultResourceProvider, cancellationToken);
         }
 
-        public static UniTask AddNewObjectAsync(this INavigationSheet navigationSheet, string key, NavigationOptions options, CancellationToken cancellationToken = default)
+        public static UniTask AddNewObjectAsync(this INavigationSheet navigationSheet, string key, NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return AddNewObjectAsync(navigationSheet, key, ResourceProvider.DefaultResourceProvider, options, cancellationToken);
+            return AddNewObjectAsync(navigationSheet, key, ResourceProvider.DefaultResourceProvider, context, cancellationToken);
         }
 
         public static UniTask AddNewObjectAsync(this INavigationSheet navigationSheet, string key, IResourceProvider resourceProvider, CancellationToken cancellationToken = default)
         {
-            return AddNewObjectAsync(navigationSheet, key, resourceProvider, navigationSheet.DefaultOptions, cancellationToken);
+            return AddNewObjectAsync(navigationSheet, key, resourceProvider, new NavigationContext(), cancellationToken);
         }
 
-        public static async UniTask AddNewObjectAsync(this INavigationSheet navigationSheet, string key, IResourceProvider resourceProvider, NavigationOptions options, CancellationToken cancellationToken = default)
+        public static async UniTask AddNewObjectAsync(this INavigationSheet navigationSheet, string key, IResourceProvider resourceProvider, NavigationContext context, CancellationToken cancellationToken = default)
         {
             var resource = await resourceProvider.LoadAsync<UnityEngine.Object>(key, cancellationToken);
 
@@ -52,9 +52,9 @@ namespace NavStack
             await navigationSheet.AddAsync(page, cancellationToken);
         }
 
-        public static UniTask HideAsync(this INavigationSheet navigation, CancellationToken cancellationToken = default)
+        public static UniTask HideAsync(this INavigationSheet navigationSheet, CancellationToken cancellationToken = default)
         {
-            return navigation.HideAsync(navigation.DefaultOptions, cancellationToken);
+            return navigationSheet.HideAsync(new NavigationContext(), cancellationToken);
         }
 
         static bool TryGetComponent<T>(UnityEngine.Object obj, out T result)

--- a/src/NavStack/Assets/NavStack/Runtime/NavigationStackCore.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/NavigationStackCore.cs
@@ -19,11 +19,11 @@ namespace NavStack
 
         bool isRunning;
 
-        public async UniTask PopAsync(NavigationOptions options, CancellationToken cancellationToken = default)
+        public async UniTask PopAsync(NavigationContext context, CancellationToken cancellationToken = default)
         {
             if (isRunning)
             {
-                switch (options.AwaitOperation)
+                switch (context.Options.AwaitOperation)
                 {
                     case NavigationAwaitOperation.Error:
                         throw new InvalidOperationException("Navigation is currently in transition.");
@@ -43,10 +43,10 @@ namespace NavStack
                 pageStack.TryPop(out var page);
                 pageStack.TryPeek(out activePage);
 
-                var task1 = NavigationHelper.InvokeOnDisappear(page, callbackReceivers, options, cancellationToken);
+                var task1 = NavigationHelper.InvokeOnDisappear(page, callbackReceivers, context, cancellationToken);
                 var task2 = activePage == null
                     ? UniTask.CompletedTask
-                    : NavigationHelper.InvokeOnAppear(activePage, callbackReceivers, options, cancellationToken);
+                    : NavigationHelper.InvokeOnAppear(activePage, callbackReceivers, context, cancellationToken);
 
                 await UniTask.WhenAll(task1, task2);
 
@@ -58,11 +58,11 @@ namespace NavStack
             }
         }
 
-        public async UniTask PushAsync(Func<UniTask<IPage>> pageFactory, NavigationOptions options, CancellationToken cancellationToken = default)
+        public async UniTask PushAsync(Func<UniTask<IPage>> pageFactory, NavigationContext context, CancellationToken cancellationToken = default)
         {
             if (isRunning)
             {
-                switch (options.AwaitOperation)
+                switch (context.Options.AwaitOperation)
                 {
                     case NavigationAwaitOperation.Error:
                         throw new InvalidOperationException("Navigation is currently in transition.");
@@ -83,8 +83,8 @@ namespace NavStack
 
                 var task1 = activePage == null
                     ? UniTask.CompletedTask
-                    : NavigationHelper.InvokeOnDisappear(activePage, callbackReceivers, options, cancellationToken);
-                var task2 = NavigationHelper.InvokeOnAppear(page, callbackReceivers, options, cancellationToken);
+                    : NavigationHelper.InvokeOnDisappear(activePage, callbackReceivers, context, cancellationToken);
+                var task2 = NavigationHelper.InvokeOnAppear(page, callbackReceivers, context, cancellationToken);
 
                 await UniTask.WhenAll(task1, task2);
 

--- a/src/NavStack/Assets/NavStack/Runtime/NavigationStackCore.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/NavigationStackCore.cs
@@ -19,11 +19,14 @@ namespace NavStack
 
         bool isRunning;
 
-        public async UniTask PopAsync(NavigationContext context, CancellationToken cancellationToken = default)
+        public async UniTask PopAsync(INavigation navigation, NavigationContext context, CancellationToken cancellationToken = default)
         {
+            var copiedContext = context.CreateCopy();
+            copiedContext.Options = context.Options ?? navigation.DefaultOptions;
+
             if (isRunning)
             {
-                switch (context.Options.AwaitOperation)
+                switch (copiedContext.Options.AwaitOperation)
                 {
                     case NavigationAwaitOperation.Error:
                         throw new InvalidOperationException("Navigation is currently in transition.");
@@ -43,10 +46,10 @@ namespace NavStack
                 pageStack.TryPop(out var page);
                 pageStack.TryPeek(out activePage);
 
-                var task1 = NavigationHelper.InvokeOnDisappear(page, callbackReceivers, context, cancellationToken);
+                var task1 = NavigationHelper.InvokeOnDisappear(page, callbackReceivers, copiedContext, cancellationToken);
                 var task2 = activePage == null
                     ? UniTask.CompletedTask
-                    : NavigationHelper.InvokeOnAppear(activePage, callbackReceivers, context, cancellationToken);
+                    : NavigationHelper.InvokeOnAppear(activePage, callbackReceivers, copiedContext, cancellationToken);
 
                 await UniTask.WhenAll(task1, task2);
 
@@ -58,11 +61,14 @@ namespace NavStack
             }
         }
 
-        public async UniTask PushAsync(Func<UniTask<IPage>> pageFactory, NavigationContext context, CancellationToken cancellationToken = default)
+        public async UniTask PushAsync(INavigation navigation, Func<UniTask<IPage>> pageFactory, NavigationContext context, CancellationToken cancellationToken = default)
         {
+            var copiedContext = context.CreateCopy();
+            copiedContext.Options = context.Options ?? navigation.DefaultOptions;
+            
             if (isRunning)
             {
-                switch (context.Options.AwaitOperation)
+                switch (copiedContext.Options.AwaitOperation)
                 {
                     case NavigationAwaitOperation.Error:
                         throw new InvalidOperationException("Navigation is currently in transition.");
@@ -83,8 +89,8 @@ namespace NavStack
 
                 var task1 = activePage == null
                     ? UniTask.CompletedTask
-                    : NavigationHelper.InvokeOnDisappear(activePage, callbackReceivers, context, cancellationToken);
-                var task2 = NavigationHelper.InvokeOnAppear(page, callbackReceivers, context, cancellationToken);
+                    : NavigationHelper.InvokeOnDisappear(activePage, callbackReceivers, copiedContext, cancellationToken);
+                var task2 = NavigationHelper.InvokeOnAppear(page, callbackReceivers, copiedContext, cancellationToken);
 
                 await UniTask.WhenAll(task1, task2);
 

--- a/src/NavStack/Assets/NavStack/Runtime/UI/NavigationSheet.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/UI/NavigationSheet.cs
@@ -84,14 +84,14 @@ namespace NavStack.UI
             return core.RemoveAllAsync(cancellationToken);
         }
 
-        public UniTask ShowAsync(int index, NavigationOptions options, CancellationToken cancellationToken = default)
+        public UniTask ShowAsync(int index, NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.ShowAsync(index, options, cancellationToken);
+            return core.ShowAsync(this, index, context, cancellationToken);
         }
 
-        public UniTask HideAsync(NavigationOptions options, CancellationToken cancellationToken = default)
+        public UniTask HideAsync(NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.HideAsync(options, cancellationToken);
+            return core.HideAsync(this, context, cancellationToken);
         }
     }
 }

--- a/src/NavStack/Assets/NavStack/Runtime/UI/NavigationStack.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/UI/NavigationStack.cs
@@ -65,19 +65,19 @@ namespace NavStack.UI
             CallbackReceivers.Add(new CallbackReceiver() { NavigationStack = this });
         }
 
-        public UniTask PopAsync(NavigationOptions options, CancellationToken cancellationToken = default)
+        public UniTask PopAsync(NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.PopAsync(options, cancellationToken);
+            return core.PopAsync(context, cancellationToken);
         }
 
-        public UniTask PushAsync(IPage page, NavigationOptions options, CancellationToken cancellationToken = default)
+        public UniTask PushAsync(IPage page, NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.PushAsync(() => new(page), options, cancellationToken);
+            return core.PushAsync(() => new(page), context, cancellationToken);
         }
 
-        public UniTask PushAsync(Func<UniTask<IPage>> factory, NavigationOptions options, CancellationToken cancellationToken = default)
+        public UniTask PushAsync(Func<UniTask<IPage>> factory, NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.PushAsync(factory, options, cancellationToken);
+            return core.PushAsync(factory, context, cancellationToken);
         }
     }
 }

--- a/src/NavStack/Assets/NavStack/Runtime/UI/NavigationStack.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/UI/NavigationStack.cs
@@ -67,17 +67,17 @@ namespace NavStack.UI
 
         public UniTask PopAsync(NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.PopAsync(context, cancellationToken);
+            return core.PopAsync(this, context, cancellationToken);
         }
 
         public UniTask PushAsync(IPage page, NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.PushAsync(() => new(page), context, cancellationToken);
+            return core.PushAsync(this, () => new(page), context, cancellationToken);
         }
 
         public UniTask PushAsync(Func<UniTask<IPage>> factory, NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return core.PushAsync(factory, context, cancellationToken);
+            return core.PushAsync(this, factory, context, cancellationToken);
         }
     }
 }

--- a/src/NavStack/Assets/NavStack/Runtime/UI/Page.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/UI/Page.cs
@@ -52,7 +52,7 @@ namespace NavStack.UI
             await OnCleanupCore(cancellationToken);
         }
 
-        public async UniTask OnDisappear(NavigationOptions options, CancellationToken cancellationToken = default)
+        public async UniTask OnDisappear(NavigationContext context, CancellationToken cancellationToken = default)
         {
             var array = ArrayPool<IPageLifecycleEvent>.Shared.Rent(events.Count);
             try
@@ -60,7 +60,7 @@ namespace NavStack.UI
                 events.CopyTo(array);
                 for (int i = 0; i < events.Count; i++)
                 {
-                    await array[i].OnDisappear(options, cancellationToken);
+                    await array[i].OnDisappear(context, cancellationToken);
                 }
             }
             finally
@@ -68,10 +68,10 @@ namespace NavStack.UI
                 ArrayPool<IPageLifecycleEvent>.Shared.Return(array);
             }
 
-            await OnDisappearCore(options, cancellationToken);
+            await OnDisappearCore(context, cancellationToken);
         }
 
-        public async UniTask OnAppear(NavigationOptions options, CancellationToken cancellationToken = default)
+        public async UniTask OnAppear(NavigationContext context, CancellationToken cancellationToken = default)
         {
             var array = ArrayPool<IPageLifecycleEvent>.Shared.Rent(events.Count);
             try
@@ -79,7 +79,7 @@ namespace NavStack.UI
                 events.CopyTo(array);
                 for (int i = 0; i < events.Count; i++)
                 {
-                    await array[i].OnAppear(options, cancellationToken);
+                    await array[i].OnAppear(context, cancellationToken);
                 }
             }
             finally
@@ -87,7 +87,7 @@ namespace NavStack.UI
                 ArrayPool<IPageLifecycleEvent>.Shared.Return(array);
             }
 
-            await OnAppearCore(options, cancellationToken);
+            await OnAppearCore(context, cancellationToken);
         }
 
         protected virtual UniTask OnInitializeCore(CancellationToken cancellationToken = default)
@@ -100,12 +100,12 @@ namespace NavStack.UI
             return UniTask.CompletedTask;
         }
 
-        protected virtual UniTask OnAppearCore(NavigationOptions options, CancellationToken cancellationToken = default)
+        protected virtual UniTask OnAppearCore(NavigationContext context, CancellationToken cancellationToken = default)
         {
             return UniTask.CompletedTask;
         }
 
-        protected virtual UniTask OnDisappearCore(NavigationOptions options, CancellationToken cancellationToken = default)
+        protected virtual UniTask OnDisappearCore(NavigationContext context, CancellationToken cancellationToken = default)
         {
             return UniTask.CompletedTask;
         }

--- a/src/NavStack/Assets/NavStack/Runtime/UI/PlayableNavigationPage.cs
+++ b/src/NavStack/Assets/NavStack/Runtime/UI/PlayableNavigationPage.cs
@@ -15,14 +15,14 @@ namespace NavStack.UI
         [SerializeField] PlayableAsset onAppearAnimation;
         [SerializeField] PlayableAsset onDisappearAnimation;
 
-        protected override UniTask OnAppearCore(NavigationOptions options, CancellationToken cancellationToken = default)
+        protected override UniTask OnAppearCore(NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return PlayAsync(onAppearAnimation, options, cancellationToken);
+            return PlayAsync(onAppearAnimation, context.Options, cancellationToken);
         }
 
-        protected override UniTask OnDisappearCore(NavigationOptions options, CancellationToken cancellationToken = default)
+        protected override UniTask OnDisappearCore(NavigationContext context, CancellationToken cancellationToken = default)
         {
-            return PlayAsync(onDisappearAnimation, options, cancellationToken);
+            return PlayAsync(onDisappearAnimation, context.Options, cancellationToken);
         }
 
         async UniTask PlayAsync(PlayableAsset asset, NavigationOptions options, CancellationToken cancellationToken)

--- a/src/NavStack/Assets/Sandbox/SamplePage1.cs
+++ b/src/NavStack/Assets/Sandbox/SamplePage1.cs
@@ -33,9 +33,9 @@ public class SamplePage1 : Page
         return base.OnInitializeCore(cancellationToken);
     }
 
-    protected override async UniTask OnAppearCore(NavigationOptions options, CancellationToken cancellationToken = default)
+    protected override async UniTask OnAppearCore(NavigationContext context, CancellationToken cancellationToken = default)
     {
-        if (!options.Animated)
+        if (!context.Options.Animated)
         {
             canvasGroup.alpha = 1f;
             return;
@@ -47,9 +47,9 @@ public class SamplePage1 : Page
             .ToUniTask(CancellationTokenSource.CreateLinkedTokenSource(destroyCancellationToken, cancellationToken).Token);
     }
 
-    protected override async UniTask OnDisappearCore(NavigationOptions options, CancellationToken cancellationToken = default)
+    protected override async UniTask OnDisappearCore(NavigationContext context, CancellationToken cancellationToken = default)
     {
-        if (!options.Animated)
+        if (!context.Options.Animated)
         {
             canvasGroup.alpha = 0f;
             return;


### PR DESCRIPTION
Introduce `NavigationContext` as an argument to be passed at transition. This allows keyed parameters to be passed to the destination in addition to `NavigationOptions`. (This is a breaking change.)